### PR TITLE
Add a access_token_file params to allow passing a rotated access token

### DIFF
--- a/access_token.go
+++ b/access_token.go
@@ -1,6 +1,10 @@
 package godatabend
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"os"
+)
 
 // AccessToken is used on Bearer authentication. The token may have a limited
 // lifetime, you can rotate your token by this interface.
@@ -21,4 +25,22 @@ func NewStaticTokenLoader(accessToken string) *StaticTokenLoader {
 
 func (l *StaticTokenLoader) LoadAccessToken(ctx context.Context) (string, error) {
 	return l.AccessToken, nil
+}
+
+type AccessTokenFileLoader struct {
+	path string
+}
+
+func NewAccessTokenFileLoader(path string) *AccessTokenFileLoader {
+	return &AccessTokenFileLoader{
+		path: path,
+	}
+}
+
+func (l *AccessTokenFileLoader) LoadAccessToken(ctx context.Context, forceRotate bool) (string, error) {
+	buf, err := os.ReadFile(l.path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read access token file: %w", err)
+	}
+	return string(buf), nil
 }

--- a/access_token.go
+++ b/access_token.go
@@ -2,8 +2,8 @@ package godatabend
 
 import (
 	"context"
-	"fmt"
-	"os"
+
+	"github.com/BurntSushi/toml"
 )
 
 // AccessToken is used on Bearer authentication. The token may have a limited
@@ -31,6 +31,10 @@ type AccessTokenFileLoader struct {
 	path string
 }
 
+type AccessTokenFileData struct {
+	AccessToken string `toml:"access_token"`
+}
+
 func NewAccessTokenFileLoader(path string) *AccessTokenFileLoader {
 	return &AccessTokenFileLoader{
 		path: path,
@@ -38,9 +42,10 @@ func NewAccessTokenFileLoader(path string) *AccessTokenFileLoader {
 }
 
 func (l *AccessTokenFileLoader) LoadAccessToken(ctx context.Context, forceRotate bool) (string, error) {
-	buf, err := os.ReadFile(l.path)
+	data := &AccessTokenFileData{}
+	_, err := toml.DecodeFile(l.path, &data)
 	if err != nil {
-		return "", fmt.Errorf("failed to read access token file: %w", err)
+		return "", err
 	}
-	return string(buf), nil
+	return data.AccessToken, nil
 }

--- a/dsn.go
+++ b/dsn.go
@@ -27,6 +27,7 @@ type Config struct {
 	Database  string // Database name
 
 	AccessToken       string
+	AccessTokenFile   string // path to file containing access token, it can be used to rotate access token
 	AccessTokenLoader AccessTokenLoader
 
 	Host    string
@@ -87,6 +88,9 @@ func (cfg *Config) FormatDSN() string {
 	}
 	if cfg.AccessToken != "" {
 		query.Set("access_token", cfg.AccessToken)
+	}
+	if cfg.AccessTokenFile != "" {
+		query.Set("access_token_file", cfg.AccessTokenFile)
 	}
 	if cfg.Timeout != 0 {
 		query.Set("timeout", cfg.Timeout.String())
@@ -185,6 +189,8 @@ func (cfg *Config) AddParams(params map[string]string) (err error) {
 			cfg.Warehouse = v
 		case "access_token":
 			cfg.AccessToken = v
+		case "access_token_file":
+			cfg.AccessTokenFile = v
 		case "sslmode":
 			cfg.SSLMode = v
 		case "default_format", "query", "database":

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -38,33 +38,42 @@ func TestConfigURL(t *testing.T) {
 }
 
 func TestParseDSN(t *testing.T) {
-	tests := []string{
-		"databend+http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings",
-		"db+http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings",
-		"bend+http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings",
-		"http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings",
-		"databend://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
-		"db://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
-		"dd://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
-		"bend://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
-		"https://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
-	}
+	t.Run("test simple dns parse", func(t *testing.T) {
+		dsn := "databend+http://app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&access_token_file=/tmp/file1"
 
-	for _, test := range tests {
-		cfg, err := ParseDSN(test)
+		cfg, err := ParseDSN(dsn)
 		require.Nil(t, err)
+		assert.Equal(t, "/tmp/file1", cfg.AccessTokenFile)
+	})
 
-		assert.Equal(t, "username", cfg.User)
-		assert.Equal(t, "password", cfg.Password)
-		assert.Equal(t, "tn", cfg.Tenant)
-		assert.Equal(t, "wh", cfg.Warehouse)
-		assert.Equal(t, "app.databend.com:8000", cfg.Host)
-		assert.Equal(t, "test", cfg.Database)
-		assert.Equal(t, "tls-settings", cfg.TLSConfig)
-		assert.Equal(t, SSL_MODE_DISABLE, cfg.SSLMode)
-		assert.Equal(t, time.Second, cfg.Timeout)
-		assert.Equal(t, int64(10), cfg.WaitTimeSecs)
-		assert.Equal(t, defaultMaxRowsInBuffer, cfg.MaxRowsInBuffer)
+	t.Run("test parse dsn with different protocols", func(t *testing.T) {
+		tests := []string{
+			"databend+http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&",
+			"db+http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings",
+			"bend+http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings",
+			"http://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings",
+			"databend://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
+			"db://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
+			"dd://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
+			"bend://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
+			"https://username:password@app.databend.com:8000/test?tenant=tn&warehouse=wh&timeout=1s&wait_time_secs=10&max_rows_in_buffer=5000000&max_rows_per_page=10000&tls_config=tls-settings&sslmode=disable",
+		}
 
-	}
+		for _, test := range tests {
+			cfg, err := ParseDSN(test)
+			require.Nil(t, err)
+
+			assert.Equal(t, "username", cfg.User)
+			assert.Equal(t, "password", cfg.Password)
+			assert.Equal(t, "tn", cfg.Tenant)
+			assert.Equal(t, "wh", cfg.Warehouse)
+			assert.Equal(t, "app.databend.com:8000", cfg.Host)
+			assert.Equal(t, "test", cfg.Database)
+			assert.Equal(t, "tls-settings", cfg.TLSConfig)
+			assert.Equal(t, SSL_MODE_DISABLE, cfg.SSLMode)
+			assert.Equal(t, time.Second, cfg.Timeout)
+			assert.Equal(t, int64(10), cfg.WaitTimeSecs)
+			assert.Equal(t, defaultMaxRowsInBuffer, cfg.MaxRowsInBuffer)
+		}
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/databendcloud/databend-go
 go 1.18
 
 require (
+	github.com/BurntSushi/toml v1.2.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/google/uuid v1.3.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
+github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/restful.go
+++ b/restful.go
@@ -31,14 +31,16 @@ const (
 type APIClient struct {
 	cli *http.Client
 
-	apiEndpoint       string
-	host              string
-	user              string
-	password          string
+	apiEndpoint string
+	host        string
+	tenant      string
+	warehouse   string
+	user        string
+	password    string
+
 	accessToken       string
+	accessTokenFile   string
 	accessTokenLoader AccessTokenLoader
-	tenant            string
-	warehouse         string
 
 	waitTimeSeconds      int64
 	maxRowsInBuffer      int64
@@ -65,6 +67,7 @@ func NewAPIClientFromConfig(cfg *Config) *APIClient {
 		user:              cfg.User,
 		password:          cfg.Password,
 		accessToken:       cfg.AccessToken,
+		accessTokenFile:   cfg.AccessTokenFile,
 		accessTokenLoader: cfg.AccessTokenLoader,
 
 		waitTimeSeconds:      cfg.WaitTimeSecs,
@@ -76,6 +79,10 @@ func NewAPIClientFromConfig(cfg *Config) *APIClient {
 
 func (c *APIClient) loadAccessToken(ctx context.Context, forceRotate bool) (string, error) {
 	if c.accessTokenLoader != nil {
+		return c.accessTokenLoader.LoadAccessToken(ctx, forceRotate)
+	}
+	if c.accessTokenFile != "" {
+		c.accessTokenLoader = NewAccessTokenFileLoader(c.accessTokenFile)
 		return c.accessTokenLoader.LoadAccessToken(ctx, forceRotate)
 	}
 	return c.accessToken, nil


### PR DESCRIPTION
this PR allows passing a rotated access_token file path to the DSN parameters.

the content of this file is a toml with `access_token` key contained, there might also contains `refresh_token`, but can be ignored by databend-go.

snowflake's jdbc takes this file approach to support a rotated private key, maybe similiar:

https://docs.snowflake.com/en/user-guide/jdbc-configure.html#privatekey-property-in-connection-properties

